### PR TITLE
fix: set gateway address to a placeholder

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -19,7 +19,7 @@ Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-fram
 # Override = { local = "../conflicting/version", override = true }
 
 [addresses]
-gateway = "0x0"
+gateway = "_"
 
 # Named addresses will be accessible in Move as `@name`. They're also exported:
 # for example, `std = "0x1"` is exported by the Standard Library.

--- a/Move.toml
+++ b/Move.toml
@@ -31,6 +31,7 @@ gateway = "_"
 # Local = { local = "../path/to/dev-build" }
 
 [dev-addresses]
+gateway = "0x0"
 # The dev-addresses section allows overwriting named addresses for the `--test`
 # and `--dev` modes.
 # alice = "0xB0B"


### PR DESCRIPTION
With this placeholder, when I import the Gateway from an example project, it seems to compile fine:

```toml
[dependencies]
Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
gateway = { git = "https://github.com/zeta-chain/protocol-contracts-sui.git", rev = "gateway-address" }

[addresses]
call = "0x0"
gateway = "0x2c8aa332520a3c3984c84c9acedeaee5421a327e031692530724b4f280516c8f"
```

```move
module call::hello_world {
    use gateway::gateway::deposit;
    ///...
}
```

https://stackoverflow.com/questions/73958046/local-dependency-cannot-be-resolved/73959597