### PR TITLE
refactor: remove unnecessary nonce for gateway

### DIFF
--- a/Move.lock
+++ b/Move.lock
@@ -21,6 +21,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.42.1"
+compiler-version = "1.42.2"
 edition = "2024.beta"
 flavor = "sui"


### PR DESCRIPTION
Object versioning (used with the gateway in this case) already enable replay attack https://docs.sui.io/concepts/versioning

Managing this nonce brings a further overhead for the interacting with ZetaClient