### PR TITLE
chore: add testnet gateway package id in move.lock

### DIFF
--- a/Move.lock
+++ b/Move.lock
@@ -24,3 +24,11 @@ dependencies = [
 compiler-version = "1.42.2"
 edition = "2024.beta"
 flavor = "sui"
+
+[env]
+
+[env.testnet]
+chain-id = "4c78adac"
+original-published-id = "0x6b2fe12c605d64e14ca69f9aba51550593ba92ff43376d0a6cc26a5ca226f9bd"
+latest-published-id = "0x6b2fe12c605d64e14ca69f9aba51550593ba92ff43376d0a6cc26a5ca226f9bd"
+published-version = "1"


### PR DESCRIPTION
This allow to register the address for documentation purpose + if we add the contract importing gateway, the address is automatically set on deploy