### PR TITLE
docs: remove links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,9 +29,8 @@ jobs:
 
       - name: sui move build --doc
         run: |
-          docker run -i -v $(pwd):/sui $SUI_IMAGE yarn docs
-          mkdir -p docs
-          rsync -a build/gateway/docs/gateway/ docs/
+          docker run -i -v $(pwd):/sui $SUI_IMAGE sui move build --doc
+          yarn docs
 
       - name: Check if docs/ changed
         id: changes

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: sui move build --doc
         run: |
-          docker run -i -v $(pwd):/sui $SUI_IMAGE sui move build --doc
+          docker run -i -v $(pwd):/sui $SUI_IMAGE yarn docs
           mkdir -p docs
           rsync -a build/gateway/docs/gateway/ docs/
 

--- a/docs/evm.md
+++ b/docs/evm.md
@@ -1,5 +1,5 @@
 
-<a name="gateway_evm"></a>
+
 
 # Module `gateway::evm`
 
@@ -9,21 +9,21 @@
 -  [Function `is_hex_vec`](#gateway_evm_is_hex_vec)
 
 
-<pre><code><b>use</b> <a href="../dependencies/std/ascii.md#std_ascii">std::ascii</a>;
-<b>use</b> <a href="../dependencies/std/option.md#std_option">std::option</a>;
-<b>use</b> <a href="../dependencies/std/vector.md#std_vector">std::vector</a>;
+<pre><code><b>use</b> std::ascii;
+<b>use</b> std::option;
+<b>use</b> std::vector;
 </code></pre>
 
 
 
-<a name="gateway_evm_is_valid_evm_address"></a>
+
 
 ## Function `is_valid_evm_address`
 
 Check if a given string is a valid Ethereum address.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/evm.md#gateway_evm_is_valid_evm_address">is_valid_evm_address</a>(addr: <a href="../dependencies/std/ascii.md#std_ascii_String">std::ascii::String</a>): bool
+<pre><code><b>public</b> <b>fun</b> is_valid_evm_address(addr: std::ascii::String): bool
 </code></pre>
 
 
@@ -32,7 +32,7 @@ Check if a given string is a valid Ethereum address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/evm.md#gateway_evm_is_valid_evm_address">is_valid_evm_address</a>(addr: String): bool {
+<pre><code><b>public</b> <b>fun</b> is_valid_evm_address(addr: String): bool {
     <b>if</b> (addr.length() != 42) {
         <b>return</b> <b>false</b>
     };
@@ -45,7 +45,7 @@ Check if a given string is a valid Ethereum address.
     addrBytes.remove(0);
     addrBytes.remove(0);
     // check <b>if</b> remaining characters are hex (0-9, a-f, A-F)
-    <a href="../gateway/evm.md#gateway_evm_is_hex_vec">is_hex_vec</a>(addrBytes)
+    is_hex_vec(addrBytes)
 }
 </code></pre>
 
@@ -53,14 +53,14 @@ Check if a given string is a valid Ethereum address.
 
 </details>
 
-<a name="gateway_evm_is_hex_vec"></a>
+
 
 ## Function `is_hex_vec`
 
 Check that vector contains only hex chars (0-9, a-f, A-F).
 
 
-<pre><code><b>fun</b> <a href="../gateway/evm.md#gateway_evm_is_hex_vec">is_hex_vec</a>(input: vector&lt;u8&gt;): bool
+<pre><code><b>fun</b> is_hex_vec(input: vector&lt;u8&gt;): bool
 </code></pre>
 
 
@@ -69,7 +69,7 @@ Check that vector contains only hex chars (0-9, a-f, A-F).
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="../gateway/evm.md#gateway_evm_is_hex_vec">is_hex_vec</a>(input: vector&lt;u8&gt;): bool {
+<pre><code><b>fun</b> is_hex_vec(input: vector&lt;u8&gt;): bool {
     <b>let</b> <b>mut</b> i = 0;
     <b>let</b> len = input.length();
     <b>while</b> (i &lt; len) {

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -61,12 +61,14 @@
 <b>use</b> sui::event;
 <b>use</b> sui::hex;
 <b>use</b> sui::object;
+<b>use</b> sui::party;
 <b>use</b> sui::sui;
 <b>use</b> sui::table;
 <b>use</b> sui::transfer;
 <b>use</b> sui::tx_context;
 <b>use</b> sui::types;
 <b>use</b> sui::url;
+<b>use</b> sui::vec_map;
 <b>use</b> sui::vec_set;
 </code></pre>
 
@@ -414,43 +416,7 @@
 
 
 
-<pre><code><b>const</b> EDepositPaused: u64 = 7;
-</code></pre>
-
-
-
-
-
-
-
-<pre><code><b>const</b> EInactiveWhitelistCap: u64 = 6;
-</code></pre>
-
-
-
-
-
-
-
-<pre><code><b>const</b> EInactiveWithdrawCap: u64 = 5;
-</code></pre>
-
-
-
-
-
-
-
 <pre><code><b>const</b> EInvalidReceiverAddress: u64 = 1;
-</code></pre>
-
-
-
-
-
-
-
-<pre><code><b>const</b> ENonceMismatch: u64 = 3;
 </code></pre>
 
 
@@ -468,7 +434,43 @@
 
 
 
+<pre><code><b>const</b> ENonceMismatch: u64 = 3;
+</code></pre>
+
+
+
+
+
+
+
 <pre><code><b>const</b> EPayloadTooLong: u64 = 4;
+</code></pre>
+
+
+
+
+
+
+
+<pre><code><b>const</b> EInactiveWithdrawCap: u64 = 5;
+</code></pre>
+
+
+
+
+
+
+
+<pre><code><b>const</b> EInactiveWhitelistCap: u64 = 6;
+</code></pre>
+
+
+
+
+
+
+
+<pre><code><b>const</b> EDepositPaused: u64 = 7;
 </code></pre>
 
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -1,5 +1,5 @@
 
-<a name="gateway_gateway"></a>
+
 
 # Module `gateway::gateway`
 
@@ -42,45 +42,45 @@
 -  [Function `coin_name`](#gateway_gateway_coin_name)
 
 
-<pre><code><b>use</b> <a href="../gateway/evm.md#gateway_evm">gateway::evm</a>;
-<b>use</b> <a href="../dependencies/std/address.md#std_address">std::address</a>;
-<b>use</b> <a href="../dependencies/std/ascii.md#std_ascii">std::ascii</a>;
-<b>use</b> <a href="../dependencies/std/bcs.md#std_bcs">std::bcs</a>;
-<b>use</b> <a href="../dependencies/std/option.md#std_option">std::option</a>;
-<b>use</b> <a href="../dependencies/std/string.md#std_string">std::string</a>;
-<b>use</b> <a href="../dependencies/std/type_name.md#std_type_name">std::type_name</a>;
-<b>use</b> <a href="../dependencies/std/vector.md#std_vector">std::vector</a>;
-<b>use</b> <a href="../dependencies/sui/address.md#sui_address">sui::address</a>;
-<b>use</b> <a href="../dependencies/sui/bag.md#sui_bag">sui::bag</a>;
-<b>use</b> <a href="../dependencies/sui/balance.md#sui_balance">sui::balance</a>;
-<b>use</b> <a href="../dependencies/sui/coin.md#sui_coin">sui::coin</a>;
-<b>use</b> <a href="../dependencies/sui/config.md#sui_config">sui::config</a>;
-<b>use</b> <a href="../dependencies/sui/deny_list.md#sui_deny_list">sui::deny_list</a>;
-<b>use</b> <a href="../dependencies/sui/dynamic_field.md#sui_dynamic_field">sui::dynamic_field</a>;
-<b>use</b> <a href="../dependencies/sui/dynamic_object_field.md#sui_dynamic_object_field">sui::dynamic_object_field</a>;
-<b>use</b> <a href="../dependencies/sui/event.md#sui_event">sui::event</a>;
-<b>use</b> <a href="../dependencies/sui/hex.md#sui_hex">sui::hex</a>;
-<b>use</b> <a href="../dependencies/sui/object.md#sui_object">sui::object</a>;
-<b>use</b> <a href="../dependencies/sui/party.md#sui_party">sui::party</a>;
-<b>use</b> <a href="../dependencies/sui/sui.md#sui_sui">sui::sui</a>;
-<b>use</b> <a href="../dependencies/sui/table.md#sui_table">sui::table</a>;
-<b>use</b> <a href="../dependencies/sui/transfer.md#sui_transfer">sui::transfer</a>;
-<b>use</b> <a href="../dependencies/sui/tx_context.md#sui_tx_context">sui::tx_context</a>;
-<b>use</b> <a href="../dependencies/sui/types.md#sui_types">sui::types</a>;
-<b>use</b> <a href="../dependencies/sui/url.md#sui_url">sui::url</a>;
-<b>use</b> <a href="../dependencies/sui/vec_map.md#sui_vec_map">sui::vec_map</a>;
-<b>use</b> <a href="../dependencies/sui/vec_set.md#sui_vec_set">sui::vec_set</a>;
+<pre><code><b>use</b> gateway::evm;
+<b>use</b> std::address;
+<b>use</b> std::ascii;
+<b>use</b> std::bcs;
+<b>use</b> std::option;
+<b>use</b> std::string;
+<b>use</b> std::type_name;
+<b>use</b> std::vector;
+<b>use</b> sui::address;
+<b>use</b> sui::bag;
+<b>use</b> sui::balance;
+<b>use</b> sui::coin;
+<b>use</b> sui::config;
+<b>use</b> sui::deny_list;
+<b>use</b> sui::dynamic_field;
+<b>use</b> sui::dynamic_object_field;
+<b>use</b> sui::event;
+<b>use</b> sui::hex;
+<b>use</b> sui::object;
+<b>use</b> sui::party;
+<b>use</b> sui::sui;
+<b>use</b> sui::table;
+<b>use</b> sui::transfer;
+<b>use</b> sui::tx_context;
+<b>use</b> sui::types;
+<b>use</b> sui::url;
+<b>use</b> sui::vec_map;
+<b>use</b> sui::vec_set;
 </code></pre>
 
 
 
-<a name="gateway_gateway_Vault"></a>
+
 
 ## Struct `Vault`
 
 
 
-<pre><code><b>public</b> <b>struct</b> <a href="../gateway/gateway.md#gateway_gateway_Vault">Vault</a>&lt;<b>phantom</b> T&gt; <b>has</b> store
+<pre><code><b>public</b> <b>struct</b> Vault&lt;<b>phantom</b> T&gt; <b>has</b> store
 </code></pre>
 
 
@@ -91,7 +91,7 @@
 
 <dl>
 <dt>
-<code>balance: <a href="../dependencies/sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;</code>
+<code>balance: sui::balance::Balance&lt;T&gt;</code>
 </dt>
 <dd>
 </dd>
@@ -105,13 +105,13 @@
 
 </details>
 
-<a name="gateway_gateway_Gateway"></a>
+
 
 ## Struct `Gateway`
 
 
 
-<pre><code><b>public</b> <b>struct</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a> <b>has</b> key
+<pre><code><b>public</b> <b>struct</b> Gateway <b>has</b> key
 </code></pre>
 
 
@@ -122,27 +122,27 @@
 
 <dl>
 <dt>
-<code>id: <a href="../dependencies/sui/object.md#sui_object_UID">sui::object::UID</a></code>
+<code>id: sui::object::UID</code>
 </dt>
 <dd>
 </dd>
 <dt>
-<code>vaults: <a href="../dependencies/sui/bag.md#sui_bag_Bag">sui::bag::Bag</a></code>
+<code>vaults: sui::bag::Bag</code>
 </dt>
 <dd>
 </dd>
 <dt>
-<code><a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: u64</code>
+<code>nonce: u64</code>
 </dt>
 <dd>
 </dd>
 <dt>
-<code><a href="../gateway/gateway.md#gateway_gateway_active_withdraw_cap">active_withdraw_cap</a>: <a href="../dependencies/sui/object.md#sui_object_ID">sui::object::ID</a></code>
+<code>active_withdraw_cap: sui::object::ID</code>
 </dt>
 <dd>
 </dd>
 <dt>
-<code><a href="../gateway/gateway.md#gateway_gateway_active_whitelist_cap">active_whitelist_cap</a>: <a href="../dependencies/sui/object.md#sui_object_ID">sui::object::ID</a></code>
+<code>active_whitelist_cap: sui::object::ID</code>
 </dt>
 <dd>
 </dd>
@@ -156,13 +156,13 @@
 
 </details>
 
-<a name="gateway_gateway_WithdrawCap"></a>
+
 
 ## Struct `WithdrawCap`
 
 
 
-<pre><code><b>public</b> <b>struct</b> <a href="../gateway/gateway.md#gateway_gateway_WithdrawCap">WithdrawCap</a> <b>has</b> key, store
+<pre><code><b>public</b> <b>struct</b> WithdrawCap <b>has</b> key, store
 </code></pre>
 
 
@@ -173,7 +173,7 @@
 
 <dl>
 <dt>
-<code>id: <a href="../dependencies/sui/object.md#sui_object_UID">sui::object::UID</a></code>
+<code>id: sui::object::UID</code>
 </dt>
 <dd>
 </dd>
@@ -182,13 +182,13 @@
 
 </details>
 
-<a name="gateway_gateway_WhitelistCap"></a>
+
 
 ## Struct `WhitelistCap`
 
 
 
-<pre><code><b>public</b> <b>struct</b> <a href="../gateway/gateway.md#gateway_gateway_WhitelistCap">WhitelistCap</a> <b>has</b> key, store
+<pre><code><b>public</b> <b>struct</b> WhitelistCap <b>has</b> key, store
 </code></pre>
 
 
@@ -199,7 +199,7 @@
 
 <dl>
 <dt>
-<code>id: <a href="../dependencies/sui/object.md#sui_object_UID">sui::object::UID</a></code>
+<code>id: sui::object::UID</code>
 </dt>
 <dd>
 </dd>
@@ -208,13 +208,13 @@
 
 </details>
 
-<a name="gateway_gateway_AdminCap"></a>
+
 
 ## Struct `AdminCap`
 
 
 
-<pre><code><b>public</b> <b>struct</b> <a href="../gateway/gateway.md#gateway_gateway_AdminCap">AdminCap</a> <b>has</b> key, store
+<pre><code><b>public</b> <b>struct</b> AdminCap <b>has</b> key, store
 </code></pre>
 
 
@@ -225,7 +225,7 @@
 
 <dl>
 <dt>
-<code>id: <a href="../dependencies/sui/object.md#sui_object_UID">sui::object::UID</a></code>
+<code>id: sui::object::UID</code>
 </dt>
 <dd>
 </dd>
@@ -234,13 +234,13 @@
 
 </details>
 
-<a name="gateway_gateway_DepositEvent"></a>
+
 
 ## Struct `DepositEvent`
 
 
 
-<pre><code><b>public</b> <b>struct</b> <a href="../gateway/gateway.md#gateway_gateway_DepositEvent">DepositEvent</a> <b>has</b> <b>copy</b>, drop
+<pre><code><b>public</b> <b>struct</b> DepositEvent <b>has</b> <b>copy</b>, drop
 </code></pre>
 
 
@@ -251,7 +251,7 @@
 
 <dl>
 <dt>
-<code>coin_type: <a href="../dependencies/std/ascii.md#std_ascii_String">std::ascii::String</a></code>
+<code>coin_type: std::ascii::String</code>
 </dt>
 <dd>
 </dd>
@@ -266,7 +266,7 @@
 <dd>
 </dd>
 <dt>
-<code>receiver: <a href="../dependencies/std/ascii.md#std_ascii_String">std::ascii::String</a></code>
+<code>receiver: std::ascii::String</code>
 </dt>
 <dd>
 </dd>
@@ -275,13 +275,13 @@
 
 </details>
 
-<a name="gateway_gateway_DepositAndCallEvent"></a>
+
 
 ## Struct `DepositAndCallEvent`
 
 
 
-<pre><code><b>public</b> <b>struct</b> <a href="../gateway/gateway.md#gateway_gateway_DepositAndCallEvent">DepositAndCallEvent</a> <b>has</b> <b>copy</b>, drop
+<pre><code><b>public</b> <b>struct</b> DepositAndCallEvent <b>has</b> <b>copy</b>, drop
 </code></pre>
 
 
@@ -292,7 +292,7 @@
 
 <dl>
 <dt>
-<code>coin_type: <a href="../dependencies/std/ascii.md#std_ascii_String">std::ascii::String</a></code>
+<code>coin_type: std::ascii::String</code>
 </dt>
 <dd>
 </dd>
@@ -307,7 +307,7 @@
 <dd>
 </dd>
 <dt>
-<code>receiver: <a href="../dependencies/std/ascii.md#std_ascii_String">std::ascii::String</a></code>
+<code>receiver: std::ascii::String</code>
 </dt>
 <dd>
 </dd>
@@ -321,13 +321,13 @@
 
 </details>
 
-<a name="gateway_gateway_WithdrawEvent"></a>
+
 
 ## Struct `WithdrawEvent`
 
 
 
-<pre><code><b>public</b> <b>struct</b> <a href="../gateway/gateway.md#gateway_gateway_WithdrawEvent">WithdrawEvent</a> <b>has</b> <b>copy</b>, drop
+<pre><code><b>public</b> <b>struct</b> WithdrawEvent <b>has</b> <b>copy</b>, drop
 </code></pre>
 
 
@@ -338,7 +338,7 @@
 
 <dl>
 <dt>
-<code>coin_type: <a href="../dependencies/std/ascii.md#std_ascii_String">std::ascii::String</a></code>
+<code>coin_type: std::ascii::String</code>
 </dt>
 <dd>
 </dd>
@@ -358,7 +358,7 @@
 <dd>
 </dd>
 <dt>
-<code><a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: u64</code>
+<code>nonce: u64</code>
 </dt>
 <dd>
 </dd>
@@ -367,13 +367,13 @@
 
 </details>
 
-<a name="gateway_gateway_NonceIncreaseEvent"></a>
+
 
 ## Struct `NonceIncreaseEvent`
 
 
 
-<pre><code><b>public</b> <b>struct</b> <a href="../gateway/gateway.md#gateway_gateway_NonceIncreaseEvent">NonceIncreaseEvent</a> <b>has</b> <b>copy</b>, drop
+<pre><code><b>public</b> <b>struct</b> NonceIncreaseEvent <b>has</b> <b>copy</b>, drop
 </code></pre>
 
 
@@ -389,7 +389,7 @@
 <dd>
 </dd>
 <dt>
-<code><a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: u64</code>
+<code>nonce: u64</code>
 </dt>
 <dd>
 </dd>
@@ -398,99 +398,99 @@
 
 </details>
 
-<a name="@Constants_0"></a>
+
 
 ## Constants
 
 
-<a name="gateway_gateway_EAlreadyWhitelisted"></a>
 
 
 
-<pre><code><b>const</b> <a href="../gateway/gateway.md#gateway_gateway_EAlreadyWhitelisted">EAlreadyWhitelisted</a>: u64 = 0;
+
+<pre><code><b>const</b> EAlreadyWhitelisted: u64 = 0;
 </code></pre>
 
 
 
-<a name="gateway_gateway_EDepositPaused"></a>
 
 
 
-<pre><code><b>const</b> <a href="../gateway/gateway.md#gateway_gateway_EDepositPaused">EDepositPaused</a>: u64 = 7;
+
+<pre><code><b>const</b> EDepositPaused: u64 = 7;
 </code></pre>
 
 
 
-<a name="gateway_gateway_EInactiveWhitelistCap"></a>
 
 
 
-<pre><code><b>const</b> <a href="../gateway/gateway.md#gateway_gateway_EInactiveWhitelistCap">EInactiveWhitelistCap</a>: u64 = 6;
+
+<pre><code><b>const</b> EInactiveWhitelistCap: u64 = 6;
 </code></pre>
 
 
 
-<a name="gateway_gateway_EInactiveWithdrawCap"></a>
 
 
 
-<pre><code><b>const</b> <a href="../gateway/gateway.md#gateway_gateway_EInactiveWithdrawCap">EInactiveWithdrawCap</a>: u64 = 5;
+
+<pre><code><b>const</b> EInactiveWithdrawCap: u64 = 5;
 </code></pre>
 
 
 
-<a name="gateway_gateway_EInvalidReceiverAddress"></a>
 
 
 
-<pre><code><b>const</b> <a href="../gateway/gateway.md#gateway_gateway_EInvalidReceiverAddress">EInvalidReceiverAddress</a>: u64 = 1;
+
+<pre><code><b>const</b> EInvalidReceiverAddress: u64 = 1;
 </code></pre>
 
 
 
-<a name="gateway_gateway_ENonceMismatch"></a>
 
 
 
-<pre><code><b>const</b> <a href="../gateway/gateway.md#gateway_gateway_ENonceMismatch">ENonceMismatch</a>: u64 = 3;
+
+<pre><code><b>const</b> ENonceMismatch: u64 = 3;
 </code></pre>
 
 
 
-<a name="gateway_gateway_ENotWhitelisted"></a>
 
 
 
-<pre><code><b>const</b> <a href="../gateway/gateway.md#gateway_gateway_ENotWhitelisted">ENotWhitelisted</a>: u64 = 2;
+
+<pre><code><b>const</b> ENotWhitelisted: u64 = 2;
 </code></pre>
 
 
 
-<a name="gateway_gateway_EPayloadTooLong"></a>
 
 
 
-<pre><code><b>const</b> <a href="../gateway/gateway.md#gateway_gateway_EPayloadTooLong">EPayloadTooLong</a>: u64 = 4;
+
+<pre><code><b>const</b> EPayloadTooLong: u64 = 4;
 </code></pre>
 
 
 
-<a name="gateway_gateway_PayloadMaxLength"></a>
 
 
 
-<pre><code><b>const</b> <a href="../gateway/gateway.md#gateway_gateway_PayloadMaxLength">PayloadMaxLength</a>: u64 = 1024;
+
+<pre><code><b>const</b> PayloadMaxLength: u64 = 1024;
 </code></pre>
 
 
 
-<a name="gateway_gateway_init"></a>
+
 
 ## Function `init`
 
 
 
-<pre><code><b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_init">init</a>(ctx: &<b>mut</b> <a href="../dependencies/sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>fun</b> init(ctx: &<b>mut</b> sui::tx_context::TxContext)
 </code></pre>
 
 
@@ -499,34 +499,34 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_init">init</a>(ctx: &<b>mut</b> TxContext) {
-    // to <a href="../gateway/gateway.md#gateway_gateway_withdraw">withdraw</a> tokens from the <a href="../gateway/gateway.md#gateway_gateway">gateway</a>, the caller must have the <a href="../gateway/gateway.md#gateway_gateway_WithdrawCap">WithdrawCap</a>
-    <b>let</b> withdraw_cap = <a href="../gateway/gateway.md#gateway_gateway_WithdrawCap">WithdrawCap</a> {
+<pre><code><b>fun</b> init(ctx: &<b>mut</b> TxContext) {
+    // to withdraw tokens from the gateway, the caller must have the WithdrawCap
+    <b>let</b> withdraw_cap = WithdrawCap {
         id: object::new(ctx),
     };
-    // to <a href="../gateway/gateway.md#gateway_gateway_whitelist">whitelist</a> a new vault, the caller must have the <a href="../gateway/gateway.md#gateway_gateway_WhitelistCap">WhitelistCap</a>
-    <b>let</b> whitelist_cap = <a href="../gateway/gateway.md#gateway_gateway_WhitelistCap">WhitelistCap</a> {
+    // to whitelist a new vault, the caller must have the WhitelistCap
+    <b>let</b> whitelist_cap = WhitelistCap {
         id: object::new(ctx),
     };
-    // to <a href="../gateway/gateway.md#gateway_gateway_whitelist">whitelist</a> a new vault, the caller must have the <a href="../gateway/gateway.md#gateway_gateway_AdminCap">AdminCap</a>
-    <b>let</b> admin_cap = <a href="../gateway/gateway.md#gateway_gateway_AdminCap">AdminCap</a> {
+    // to whitelist a new vault, the caller must have the AdminCap
+    <b>let</b> admin_cap = AdminCap {
         id: object::new(ctx),
     };
-    // create and share the <a href="../gateway/gateway.md#gateway_gateway">gateway</a> object
-    <b>let</b> <b>mut</b> <a href="../gateway/gateway.md#gateway_gateway">gateway</a> = <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a> {
+    // create and share the gateway object
+    <b>let</b> <b>mut</b> gateway = Gateway {
         id: object::new(ctx),
         vaults: bag::new(ctx),
-        <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: 0,
-        <a href="../gateway/gateway.md#gateway_gateway_active_withdraw_cap">active_withdraw_cap</a>: object::id(&withdraw_cap),
-        <a href="../gateway/gateway.md#gateway_gateway_active_whitelist_cap">active_whitelist_cap</a>: object::id(&whitelist_cap),
+        nonce: 0,
+        active_withdraw_cap: object::id(&withdraw_cap),
+        active_whitelist_cap: object::id(&whitelist_cap),
         deposit_paused: <b>false</b>,
     };
-    // <a href="../gateway/gateway.md#gateway_gateway_whitelist">whitelist</a> SUI by default
-    <a href="../gateway/gateway.md#gateway_gateway_whitelist_impl">whitelist_impl</a>&lt;SUI&gt;(&<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway">gateway</a>, &whitelist_cap);
+    // whitelist SUI by default
+    whitelist_impl&lt;SUI&gt;(&<b>mut</b> gateway, &whitelist_cap);
     transfer::transfer(withdraw_cap, tx_context::sender(ctx));
     transfer::transfer(whitelist_cap, tx_context::sender(ctx));
     transfer::transfer(admin_cap, tx_context::sender(ctx));
-    transfer::share_object(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>);
+    transfer::share_object(gateway);
 }
 </code></pre>
 
@@ -534,13 +534,13 @@
 
 </details>
 
-<a name="gateway_gateway_increase_nonce"></a>
+
 
 ## Function `increase_nonce`
 
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_increase_nonce">increase_nonce</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: u64, cap: &<a href="../gateway/gateway.md#gateway_gateway_WithdrawCap">gateway::gateway::WithdrawCap</a>, ctx: &<a href="../dependencies/sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>entry</b> <b>fun</b> increase_nonce(gateway: &<b>mut</b> gateway::gateway::Gateway, nonce: u64, cap: &gateway::gateway::WithdrawCap, ctx: &sui::tx_context::TxContext)
 </code></pre>
 
 
@@ -549,14 +549,14 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_increase_nonce">increase_nonce</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>, <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: u64, cap: &<a href="../gateway/gateway.md#gateway_gateway_WithdrawCap">WithdrawCap</a>, ctx: &TxContext) {
-    <b>assert</b>!(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_active_withdraw_cap">active_withdraw_cap</a> == object::id(cap), <a href="../gateway/gateway.md#gateway_gateway_EInactiveWithdrawCap">EInactiveWithdrawCap</a>);
-    <b>assert</b>!(<a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a> == <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>, <a href="../gateway/gateway.md#gateway_gateway_ENonceMismatch">ENonceMismatch</a>);
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a> = <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a> + 1;
+<pre><code><b>entry</b> <b>fun</b> increase_nonce(gateway: &<b>mut</b> Gateway, nonce: u64, cap: &WithdrawCap, ctx: &TxContext) {
+    <b>assert</b>!(gateway.active_withdraw_cap == object::id(cap), EInactiveWithdrawCap);
+    <b>assert</b>!(nonce == gateway.nonce, ENonceMismatch);
+    gateway.nonce = nonce + 1;
     // Emit event
-    event::emit(<a href="../gateway/gateway.md#gateway_gateway_NonceIncreaseEvent">NonceIncreaseEvent</a> {
+    event::emit(NonceIncreaseEvent {
         sender: tx_context::sender(ctx),
-        <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>,
+        nonce: gateway.nonce,
     });
 }
 </code></pre>
@@ -565,13 +565,13 @@
 
 </details>
 
-<a name="gateway_gateway_withdraw"></a>
+
 
 ## Function `withdraw`
 
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_withdraw">withdraw</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, amount: u64, <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: u64, receiver: <b>address</b>, gas_budget: u64, cap: &<a href="../gateway/gateway.md#gateway_gateway_WithdrawCap">gateway::gateway::WithdrawCap</a>, ctx: &<b>mut</b> <a href="../dependencies/sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>entry</b> <b>fun</b> withdraw&lt;T&gt;(gateway: &<b>mut</b> gateway::gateway::Gateway, amount: u64, nonce: u64, receiver: <b>address</b>, gas_budget: u64, cap: &gateway::gateway::WithdrawCap, ctx: &<b>mut</b> sui::tx_context::TxContext)
 </code></pre>
 
 
@@ -580,25 +580,25 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_withdraw">withdraw</a>&lt;T&gt;(
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>,
+<pre><code><b>entry</b> <b>fun</b> withdraw&lt;T&gt;(
+    gateway: &<b>mut</b> Gateway,
     amount: u64,
-    <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: u64,
+    nonce: u64,
     receiver: <b>address</b>,
     gas_budget: u64,
-    cap: &<a href="../gateway/gateway.md#gateway_gateway_WithdrawCap">WithdrawCap</a>,
+    cap: &WithdrawCap,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> (coins, coins_gas_budget) = <a href="../gateway/gateway.md#gateway_gateway_withdraw_impl">withdraw_impl</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>, amount, <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>, gas_budget, cap, ctx);
+    <b>let</b> (coins, coins_gas_budget) = withdraw_impl&lt;T&gt;(gateway, amount, nonce, gas_budget, cap, ctx);
     transfer::public_transfer(coins, receiver);
     transfer::public_transfer(coins_gas_budget, tx_context::sender(ctx));
     // Emit event
-    event::emit(<a href="../gateway/gateway.md#gateway_gateway_WithdrawEvent">WithdrawEvent</a> {
-        coin_type: <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;T&gt;(),
+    event::emit(WithdrawEvent {
+        coin_type: coin_name&lt;T&gt;(),
         amount: amount,
         sender: tx_context::sender(ctx),
         receiver: receiver,
-        <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>,
+        nonce: nonce,
     });
 }
 </code></pre>
@@ -607,13 +607,13 @@
 
 </details>
 
-<a name="gateway_gateway_whitelist"></a>
+
 
 ## Function `whitelist`
 
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_whitelist">whitelist</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, cap: &<a href="../gateway/gateway.md#gateway_gateway_WhitelistCap">gateway::gateway::WhitelistCap</a>)
+<pre><code><b>entry</b> <b>fun</b> whitelist&lt;T&gt;(gateway: &<b>mut</b> gateway::gateway::Gateway, cap: &gateway::gateway::WhitelistCap)
 </code></pre>
 
 
@@ -622,8 +622,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_whitelist">whitelist</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>, cap: &<a href="../gateway/gateway.md#gateway_gateway_WhitelistCap">WhitelistCap</a>) {
-    <a href="../gateway/gateway.md#gateway_gateway_whitelist_impl">whitelist_impl</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>, cap)
+<pre><code><b>entry</b> <b>fun</b> whitelist&lt;T&gt;(gateway: &<b>mut</b> Gateway, cap: &WhitelistCap) {
+    whitelist_impl&lt;T&gt;(gateway, cap)
 }
 </code></pre>
 
@@ -631,13 +631,13 @@
 
 </details>
 
-<a name="gateway_gateway_unwhitelist"></a>
+
 
 ## Function `unwhitelist`
 
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_unwhitelist">unwhitelist</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">gateway::gateway::AdminCap</a>)
+<pre><code><b>entry</b> <b>fun</b> unwhitelist&lt;T&gt;(gateway: &<b>mut</b> gateway::gateway::Gateway, cap: &gateway::gateway::AdminCap)
 </code></pre>
 
 
@@ -646,8 +646,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_unwhitelist">unwhitelist</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>, cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">AdminCap</a>) {
-    <a href="../gateway/gateway.md#gateway_gateway_unwhitelist_impl">unwhitelist_impl</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>, cap)
+<pre><code><b>entry</b> <b>fun</b> unwhitelist&lt;T&gt;(gateway: &<b>mut</b> Gateway, cap: &AdminCap) {
+    unwhitelist_impl&lt;T&gt;(gateway, cap)
 }
 </code></pre>
 
@@ -655,13 +655,13 @@
 
 </details>
 
-<a name="gateway_gateway_issue_withdraw_and_whitelist_cap"></a>
+
 
 ## Function `issue_withdraw_and_whitelist_cap`
 
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_issue_withdraw_and_whitelist_cap">issue_withdraw_and_whitelist_cap</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, _cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">gateway::gateway::AdminCap</a>, ctx: &<b>mut</b> <a href="../dependencies/sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>entry</b> <b>fun</b> issue_withdraw_and_whitelist_cap(gateway: &<b>mut</b> gateway::gateway::Gateway, _cap: &gateway::gateway::AdminCap, ctx: &<b>mut</b> sui::tx_context::TxContext)
 </code></pre>
 
 
@@ -670,12 +670,12 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_issue_withdraw_and_whitelist_cap">issue_withdraw_and_whitelist_cap</a>(
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>,
-    _cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">AdminCap</a>,
+<pre><code><b>entry</b> <b>fun</b> issue_withdraw_and_whitelist_cap(
+    gateway: &<b>mut</b> Gateway,
+    _cap: &AdminCap,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> (withdraw_cap, whitelist_cap) = <a href="../gateway/gateway.md#gateway_gateway_issue_withdraw_and_whitelist_cap_impl">issue_withdraw_and_whitelist_cap_impl</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>, _cap, ctx);
+    <b>let</b> (withdraw_cap, whitelist_cap) = issue_withdraw_and_whitelist_cap_impl(gateway, _cap, ctx);
     transfer::transfer(withdraw_cap, tx_context::sender(ctx));
     transfer::transfer(whitelist_cap, tx_context::sender(ctx));
 }
@@ -685,13 +685,13 @@
 
 </details>
 
-<a name="gateway_gateway_pause"></a>
+
 
 ## Function `pause`
 
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_pause">pause</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">gateway::gateway::AdminCap</a>)
+<pre><code><b>entry</b> <b>fun</b> pause(gateway: &<b>mut</b> gateway::gateway::Gateway, cap: &gateway::gateway::AdminCap)
 </code></pre>
 
 
@@ -700,8 +700,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_pause">pause</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>, cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">AdminCap</a>) {
-    <a href="../gateway/gateway.md#gateway_gateway_pause_impl">pause_impl</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>, cap)
+<pre><code><b>entry</b> <b>fun</b> pause(gateway: &<b>mut</b> Gateway, cap: &AdminCap) {
+    pause_impl(gateway, cap)
 }
 </code></pre>
 
@@ -709,13 +709,13 @@
 
 </details>
 
-<a name="gateway_gateway_unpause"></a>
+
 
 ## Function `unpause`
 
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_unpause">unpause</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">gateway::gateway::AdminCap</a>)
+<pre><code><b>entry</b> <b>fun</b> unpause(gateway: &<b>mut</b> gateway::gateway::Gateway, cap: &gateway::gateway::AdminCap)
 </code></pre>
 
 
@@ -724,8 +724,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_unpause">unpause</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>, cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">AdminCap</a>) {
-    <a href="../gateway/gateway.md#gateway_gateway_unpause_impl">unpause_impl</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>, cap)
+<pre><code><b>entry</b> <b>fun</b> unpause(gateway: &<b>mut</b> Gateway, cap: &AdminCap) {
+    unpause_impl(gateway, cap)
 }
 </code></pre>
 
@@ -733,13 +733,13 @@
 
 </details>
 
-<a name="gateway_gateway_reset_nonce"></a>
+
 
 ## Function `reset_nonce`
 
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_reset_nonce">reset_nonce</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: u64, _cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">gateway::gateway::AdminCap</a>)
+<pre><code><b>entry</b> <b>fun</b> reset_nonce(gateway: &<b>mut</b> gateway::gateway::Gateway, nonce: u64, _cap: &gateway::gateway::AdminCap)
 </code></pre>
 
 
@@ -748,8 +748,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_reset_nonce">reset_nonce</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>, <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: u64, _cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">AdminCap</a>) {
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a> = <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>;
+<pre><code><b>entry</b> <b>fun</b> reset_nonce(gateway: &<b>mut</b> Gateway, nonce: u64, _cap: &AdminCap) {
+    gateway.nonce = nonce;
 }
 </code></pre>
 
@@ -757,13 +757,13 @@
 
 </details>
 
-<a name="gateway_gateway_deposit"></a>
+
 
 ## Function `deposit`
 
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_deposit">deposit</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, coins: <a href="../dependencies/sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;, receiver: <a href="../dependencies/std/ascii.md#std_ascii_String">std::ascii::String</a>, ctx: &<b>mut</b> <a href="../dependencies/sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> deposit&lt;T&gt;(gateway: &<b>mut</b> gateway::gateway::Gateway, coins: sui::coin::Coin&lt;T&gt;, receiver: std::ascii::String, ctx: &<b>mut</b> sui::tx_context::TxContext)
 </code></pre>
 
 
@@ -772,18 +772,18 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_deposit">deposit</a>&lt;T&gt;(
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>,
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> deposit&lt;T&gt;(
+    gateway: &<b>mut</b> Gateway,
     coins: Coin&lt;T&gt;,
     receiver: String,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> amount = coins.value();
-    <b>let</b> <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a> = <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;T&gt;();
-    <a href="../gateway/gateway.md#gateway_gateway_check_receiver_and_deposit_to_vault">check_receiver_and_deposit_to_vault</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>, coins, receiver);
-    // Emit <a href="../gateway/gateway.md#gateway_gateway_deposit">deposit</a> event
-    event::emit(<a href="../gateway/gateway.md#gateway_gateway_DepositEvent">DepositEvent</a> {
-        coin_type: <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>,
+    <b>let</b> coin_name = coin_name&lt;T&gt;();
+    check_receiver_and_deposit_to_vault(gateway, coins, receiver);
+    // Emit deposit event
+    event::emit(DepositEvent {
+        coin_type: coin_name,
         amount: amount,
         sender: tx_context::sender(ctx),
         receiver: receiver,
@@ -795,13 +795,13 @@
 
 </details>
 
-<a name="gateway_gateway_deposit_and_call"></a>
+
 
 ## Function `deposit_and_call`
 
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_deposit_and_call">deposit_and_call</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, coins: <a href="../dependencies/sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;, receiver: <a href="../dependencies/std/ascii.md#std_ascii_String">std::ascii::String</a>, payload: vector&lt;u8&gt;, ctx: &<b>mut</b> <a href="../dependencies/sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> deposit_and_call&lt;T&gt;(gateway: &<b>mut</b> gateway::gateway::Gateway, coins: sui::coin::Coin&lt;T&gt;, receiver: std::ascii::String, payload: vector&lt;u8&gt;, ctx: &<b>mut</b> sui::tx_context::TxContext)
 </code></pre>
 
 
@@ -810,20 +810,20 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_deposit_and_call">deposit_and_call</a>&lt;T&gt;(
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>,
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> deposit_and_call&lt;T&gt;(
+    gateway: &<b>mut</b> Gateway,
     coins: Coin&lt;T&gt;,
     receiver: String,
     payload: vector&lt;u8&gt;,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>assert</b>!(payload.length() &lt;= <a href="../gateway/gateway.md#gateway_gateway_PayloadMaxLength">PayloadMaxLength</a>, <a href="../gateway/gateway.md#gateway_gateway_EPayloadTooLong">EPayloadTooLong</a>);
+    <b>assert</b>!(payload.length() &lt;= PayloadMaxLength, EPayloadTooLong);
     <b>let</b> amount = coins.value();
-    <b>let</b> <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a> = <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;T&gt;();
-    <a href="../gateway/gateway.md#gateway_gateway_check_receiver_and_deposit_to_vault">check_receiver_and_deposit_to_vault</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>, coins, receiver);
-    // Emit <a href="../gateway/gateway.md#gateway_gateway_deposit">deposit</a> event
-    event::emit(<a href="../gateway/gateway.md#gateway_gateway_DepositAndCallEvent">DepositAndCallEvent</a> {
-        coin_type: <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>,
+    <b>let</b> coin_name = coin_name&lt;T&gt;();
+    check_receiver_and_deposit_to_vault(gateway, coins, receiver);
+    // Emit deposit event
+    event::emit(DepositAndCallEvent {
+        coin_type: coin_name,
         amount: amount,
         sender: tx_context::sender(ctx),
         receiver: receiver,
@@ -836,13 +836,13 @@
 
 </details>
 
-<a name="gateway_gateway_check_receiver_and_deposit_to_vault"></a>
+
 
 ## Function `check_receiver_and_deposit_to_vault`
 
 
 
-<pre><code><b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_check_receiver_and_deposit_to_vault">check_receiver_and_deposit_to_vault</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, coins: <a href="../dependencies/sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;, receiver: <a href="../dependencies/std/ascii.md#std_ascii_String">std::ascii::String</a>)
+<pre><code><b>fun</b> check_receiver_and_deposit_to_vault&lt;T&gt;(gateway: &<b>mut</b> gateway::gateway::Gateway, coins: sui::coin::Coin&lt;T&gt;, receiver: std::ascii::String)
 </code></pre>
 
 
@@ -851,17 +851,17 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_check_receiver_and_deposit_to_vault">check_receiver_and_deposit_to_vault</a>&lt;T&gt;(
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>,
+<pre><code><b>fun</b> check_receiver_and_deposit_to_vault&lt;T&gt;(
+    gateway: &<b>mut</b> Gateway,
     coins: Coin&lt;T&gt;,
     receiver: String,
 ) {
-    <b>assert</b>!(<a href="../gateway/evm.md#gateway_evm_is_valid_evm_address">evm::is_valid_evm_address</a>(receiver), <a href="../gateway/gateway.md#gateway_gateway_EInvalidReceiverAddress">EInvalidReceiverAddress</a>);
-    <b>assert</b>!(<a href="../gateway/gateway.md#gateway_gateway_is_whitelisted">is_whitelisted</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>), <a href="../gateway/gateway.md#gateway_gateway_ENotWhitelisted">ENotWhitelisted</a>);
-    <b>assert</b>!(!<a href="../gateway/gateway.md#gateway_gateway">gateway</a>.deposit_paused, <a href="../gateway/gateway.md#gateway_gateway_EDepositPaused">EDepositPaused</a>);
+    <b>assert</b>!(evm::is_valid_evm_address(receiver), EInvalidReceiverAddress);
+    <b>assert</b>!(is_whitelisted&lt;T&gt;(gateway), ENotWhitelisted);
+    <b>assert</b>!(!gateway.deposit_paused, EDepositPaused);
     // Deposit the coin into the vault
-    <b>let</b> <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a> = <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;T&gt;();
-    <b>let</b> vault = bag::borrow_mut&lt;String, <a href="../gateway/gateway.md#gateway_gateway_Vault">Vault</a>&lt;T&gt;&gt;(&<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.vaults, <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>);
+    <b>let</b> coin_name = coin_name&lt;T&gt;();
+    <b>let</b> vault = bag::borrow_mut&lt;String, Vault&lt;T&gt;&gt;(&<b>mut</b> gateway.vaults, coin_name);
     balance::join(&<b>mut</b> vault.balance, coins.into_balance());
 }
 </code></pre>
@@ -870,13 +870,13 @@
 
 </details>
 
-<a name="gateway_gateway_withdraw_impl"></a>
+
 
 ## Function `withdraw_impl`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_withdraw_impl">withdraw_impl</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, amount: u64, <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: u64, gas_budget: u64, cap: &<a href="../gateway/gateway.md#gateway_gateway_WithdrawCap">gateway::gateway::WithdrawCap</a>, ctx: &<b>mut</b> <a href="../dependencies/sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): (<a href="../dependencies/sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;, <a href="../dependencies/sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;<a href="../dependencies/sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;)
+<pre><code><b>public</b> <b>fun</b> withdraw_impl&lt;T&gt;(gateway: &<b>mut</b> gateway::gateway::Gateway, amount: u64, nonce: u64, gas_budget: u64, cap: &gateway::gateway::WithdrawCap, ctx: &<b>mut</b> sui::tx_context::TxContext): (sui::coin::Coin&lt;T&gt;, sui::coin::Coin&lt;sui::sui::SUI&gt;)
 </code></pre>
 
 
@@ -885,26 +885,26 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_withdraw_impl">withdraw_impl</a>&lt;T&gt;(
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>,
+<pre><code><b>public</b> <b>fun</b> withdraw_impl&lt;T&gt;(
+    gateway: &<b>mut</b> Gateway,
     amount: u64,
-    <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>: u64,
+    nonce: u64,
     gas_budget: u64,
-    cap: &<a href="../gateway/gateway.md#gateway_gateway_WithdrawCap">WithdrawCap</a>,
+    cap: &WithdrawCap,
     ctx: &<b>mut</b> TxContext,
-): (Coin&lt;T&gt;, Coin&lt;<a href="../dependencies/sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;) {
-    <b>assert</b>!(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_active_withdraw_cap">active_withdraw_cap</a> == object::id(cap), <a href="../gateway/gateway.md#gateway_gateway_EInactiveWithdrawCap">EInactiveWithdrawCap</a>);
-    <b>assert</b>!(<a href="../gateway/gateway.md#gateway_gateway_is_whitelisted">is_whitelisted</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>), <a href="../gateway/gateway.md#gateway_gateway_ENotWhitelisted">ENotWhitelisted</a>);
-    <b>assert</b>!(<a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a> == <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>, <a href="../gateway/gateway.md#gateway_gateway_ENonceMismatch">ENonceMismatch</a>); // prevent replay
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a> = <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a> + 1;
+): (Coin&lt;T&gt;, Coin&lt;sui::sui::SUI&gt;) {
+    <b>assert</b>!(gateway.active_withdraw_cap == object::id(cap), EInactiveWithdrawCap);
+    <b>assert</b>!(is_whitelisted&lt;T&gt;(gateway), ENotWhitelisted);
+    <b>assert</b>!(nonce == gateway.nonce, ENonceMismatch); // prevent replay
+    gateway.nonce = nonce + 1;
     // Withdraw the coin from the vault
-    <b>let</b> <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a> = <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;T&gt;();
-    <b>let</b> vault = bag::borrow_mut&lt;String, <a href="../gateway/gateway.md#gateway_gateway_Vault">Vault</a>&lt;T&gt;&gt;(&<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.vaults, <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>);
+    <b>let</b> coin_name = coin_name&lt;T&gt;();
+    <b>let</b> vault = bag::borrow_mut&lt;String, Vault&lt;T&gt;&gt;(&<b>mut</b> gateway.vaults, coin_name);
     <b>let</b> coins_out = coin::take(&<b>mut</b> vault.balance, amount, ctx);
     // Withdraw SUI to cover the gas budget
-    <b>let</b> sui_vault = bag::borrow_mut&lt;String, <a href="../gateway/gateway.md#gateway_gateway_Vault">Vault</a>&lt;<a href="../dependencies/sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;&gt;(
-        &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.vaults,
-        <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;<a href="../dependencies/sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;(),
+    <b>let</b> sui_vault = bag::borrow_mut&lt;String, Vault&lt;sui::sui::SUI&gt;&gt;(
+        &<b>mut</b> gateway.vaults,
+        coin_name&lt;sui::sui::SUI&gt;(),
     );
     <b>let</b> coins_gas_budget = coin::take(&<b>mut</b> sui_vault.balance, gas_budget, ctx);
     (coins_out, coins_gas_budget)
@@ -915,13 +915,13 @@
 
 </details>
 
-<a name="gateway_gateway_whitelist_impl"></a>
+
 
 ## Function `whitelist_impl`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_whitelist_impl">whitelist_impl</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, cap: &<a href="../gateway/gateway.md#gateway_gateway_WhitelistCap">gateway::gateway::WhitelistCap</a>)
+<pre><code><b>public</b> <b>fun</b> whitelist_impl&lt;T&gt;(gateway: &<b>mut</b> gateway::gateway::Gateway, cap: &gateway::gateway::WhitelistCap)
 </code></pre>
 
 
@@ -930,20 +930,20 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_whitelist_impl">whitelist_impl</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>, cap: &<a href="../gateway/gateway.md#gateway_gateway_WhitelistCap">WhitelistCap</a>) {
-    <b>assert</b>!(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_active_whitelist_cap">active_whitelist_cap</a> == object::id(cap), <a href="../gateway/gateway.md#gateway_gateway_EInactiveWhitelistCap">EInactiveWhitelistCap</a>);
-    <b>assert</b>!(<a href="../gateway/gateway.md#gateway_gateway_is_whitelisted">is_whitelisted</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>) == <b>false</b>, <a href="../gateway/gateway.md#gateway_gateway_EAlreadyWhitelisted">EAlreadyWhitelisted</a>);
+<pre><code><b>public</b> <b>fun</b> whitelist_impl&lt;T&gt;(gateway: &<b>mut</b> Gateway, cap: &WhitelistCap) {
+    <b>assert</b>!(gateway.active_whitelist_cap == object::id(cap), EInactiveWhitelistCap);
+    <b>assert</b>!(is_whitelisted&lt;T&gt;(gateway) == <b>false</b>, EAlreadyWhitelisted);
     // <b>if</b> the vault already exists, set it to whitelisted, otherwise create a new vault
-    <b>if</b> (bag::contains_with_type&lt;String, <a href="../gateway/gateway.md#gateway_gateway_Vault">Vault</a>&lt;T&gt;&gt;(&<a href="../gateway/gateway.md#gateway_gateway">gateway</a>.vaults, <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;T&gt;())) {
-        <b>let</b> vault = bag::borrow_mut&lt;String, <a href="../gateway/gateway.md#gateway_gateway_Vault">Vault</a>&lt;T&gt;&gt;(&<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.vaults, <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;T&gt;());
+    <b>if</b> (bag::contains_with_type&lt;String, Vault&lt;T&gt;&gt;(&gateway.vaults, coin_name&lt;T&gt;())) {
+        <b>let</b> vault = bag::borrow_mut&lt;String, Vault&lt;T&gt;&gt;(&<b>mut</b> gateway.vaults, coin_name&lt;T&gt;());
         vault.whitelisted = <b>true</b>;
     } <b>else</b> {
-        <b>let</b> vault_name = <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;T&gt;();
-        <b>let</b> vault = <a href="../gateway/gateway.md#gateway_gateway_Vault">Vault</a>&lt;T&gt; {
+        <b>let</b> vault_name = coin_name&lt;T&gt;();
+        <b>let</b> vault = Vault&lt;T&gt; {
             balance: balance::zero&lt;T&gt;(),
             whitelisted: <b>true</b>,
         };
-        bag::add(&<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.vaults, vault_name, vault);
+        bag::add(&<b>mut</b> gateway.vaults, vault_name, vault);
     }
 }
 </code></pre>
@@ -952,13 +952,13 @@
 
 </details>
 
-<a name="gateway_gateway_unwhitelist_impl"></a>
+
 
 ## Function `unwhitelist_impl`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_unwhitelist_impl">unwhitelist_impl</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, _cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">gateway::gateway::AdminCap</a>)
+<pre><code><b>public</b> <b>fun</b> unwhitelist_impl&lt;T&gt;(gateway: &<b>mut</b> gateway::gateway::Gateway, _cap: &gateway::gateway::AdminCap)
 </code></pre>
 
 
@@ -967,9 +967,9 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_unwhitelist_impl">unwhitelist_impl</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>, _cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">AdminCap</a>) {
-    <b>assert</b>!(<a href="../gateway/gateway.md#gateway_gateway_is_whitelisted">is_whitelisted</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>), <a href="../gateway/gateway.md#gateway_gateway_ENotWhitelisted">ENotWhitelisted</a>);
-    <b>let</b> vault = bag::borrow_mut&lt;String, <a href="../gateway/gateway.md#gateway_gateway_Vault">Vault</a>&lt;T&gt;&gt;(&<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.vaults, <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;T&gt;());
+<pre><code><b>public</b> <b>fun</b> unwhitelist_impl&lt;T&gt;(gateway: &<b>mut</b> Gateway, _cap: &AdminCap) {
+    <b>assert</b>!(is_whitelisted&lt;T&gt;(gateway), ENotWhitelisted);
+    <b>let</b> vault = bag::borrow_mut&lt;String, Vault&lt;T&gt;&gt;(&<b>mut</b> gateway.vaults, coin_name&lt;T&gt;());
     vault.whitelisted = <b>false</b>;
 }
 </code></pre>
@@ -978,13 +978,13 @@
 
 </details>
 
-<a name="gateway_gateway_issue_withdraw_and_whitelist_cap_impl"></a>
+
 
 ## Function `issue_withdraw_and_whitelist_cap_impl`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_issue_withdraw_and_whitelist_cap_impl">issue_withdraw_and_whitelist_cap_impl</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, _cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">gateway::gateway::AdminCap</a>, ctx: &<b>mut</b> <a href="../dependencies/sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): (<a href="../gateway/gateway.md#gateway_gateway_WithdrawCap">gateway::gateway::WithdrawCap</a>, <a href="../gateway/gateway.md#gateway_gateway_WhitelistCap">gateway::gateway::WhitelistCap</a>)
+<pre><code><b>public</b> <b>fun</b> issue_withdraw_and_whitelist_cap_impl(gateway: &<b>mut</b> gateway::gateway::Gateway, _cap: &gateway::gateway::AdminCap, ctx: &<b>mut</b> sui::tx_context::TxContext): (gateway::gateway::WithdrawCap, gateway::gateway::WhitelistCap)
 </code></pre>
 
 
@@ -993,19 +993,19 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_issue_withdraw_and_whitelist_cap_impl">issue_withdraw_and_whitelist_cap_impl</a>(
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>,
-    _cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">AdminCap</a>,
+<pre><code><b>public</b> <b>fun</b> issue_withdraw_and_whitelist_cap_impl(
+    gateway: &<b>mut</b> Gateway,
+    _cap: &AdminCap,
     ctx: &<b>mut</b> TxContext,
-): (<a href="../gateway/gateway.md#gateway_gateway_WithdrawCap">WithdrawCap</a>, <a href="../gateway/gateway.md#gateway_gateway_WhitelistCap">WhitelistCap</a>) {
-    <b>let</b> withdraw_cap = <a href="../gateway/gateway.md#gateway_gateway_WithdrawCap">WithdrawCap</a> {
+): (WithdrawCap, WhitelistCap) {
+    <b>let</b> withdraw_cap = WithdrawCap {
         id: object::new(ctx),
     };
-    <b>let</b> whitelist_cap = <a href="../gateway/gateway.md#gateway_gateway_WhitelistCap">WhitelistCap</a> {
+    <b>let</b> whitelist_cap = WhitelistCap {
         id: object::new(ctx),
     };
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_active_withdraw_cap">active_withdraw_cap</a> = object::id(&withdraw_cap);
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_active_whitelist_cap">active_whitelist_cap</a> = object::id(&whitelist_cap);
+    gateway.active_withdraw_cap = object::id(&withdraw_cap);
+    gateway.active_whitelist_cap = object::id(&whitelist_cap);
     (withdraw_cap, whitelist_cap)
 }
 </code></pre>
@@ -1014,13 +1014,13 @@
 
 </details>
 
-<a name="gateway_gateway_pause_impl"></a>
+
 
 ## Function `pause_impl`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_pause_impl">pause_impl</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, _cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">gateway::gateway::AdminCap</a>)
+<pre><code><b>public</b> <b>fun</b> pause_impl(gateway: &<b>mut</b> gateway::gateway::Gateway, _cap: &gateway::gateway::AdminCap)
 </code></pre>
 
 
@@ -1029,8 +1029,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_pause_impl">pause_impl</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>, _cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">AdminCap</a>) {
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.deposit_paused = <b>true</b>;
+<pre><code><b>public</b> <b>fun</b> pause_impl(gateway: &<b>mut</b> Gateway, _cap: &AdminCap) {
+    gateway.deposit_paused = <b>true</b>;
 }
 </code></pre>
 
@@ -1038,13 +1038,13 @@
 
 </details>
 
-<a name="gateway_gateway_unpause_impl"></a>
+
 
 ## Function `unpause_impl`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_unpause_impl">unpause_impl</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>, _cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">gateway::gateway::AdminCap</a>)
+<pre><code><b>public</b> <b>fun</b> unpause_impl(gateway: &<b>mut</b> gateway::gateway::Gateway, _cap: &gateway::gateway::AdminCap)
 </code></pre>
 
 
@@ -1053,8 +1053,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_unpause_impl">unpause_impl</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<b>mut</b> <a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>, _cap: &<a href="../gateway/gateway.md#gateway_gateway_AdminCap">AdminCap</a>) {
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.deposit_paused = <b>false</b>;
+<pre><code><b>public</b> <b>fun</b> unpause_impl(gateway: &<b>mut</b> Gateway, _cap: &AdminCap) {
+    gateway.deposit_paused = <b>false</b>;
 }
 </code></pre>
 
@@ -1062,13 +1062,13 @@
 
 </details>
 
-<a name="gateway_gateway_nonce"></a>
+
 
 ## Function `nonce`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>): u64
+<pre><code><b>public</b> <b>fun</b> nonce(gateway: &gateway::gateway::Gateway): u64
 </code></pre>
 
 
@@ -1077,8 +1077,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>): u64 {
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_nonce">nonce</a>
+<pre><code><b>public</b> <b>fun</b> nonce(gateway: &Gateway): u64 {
+    gateway.nonce
 }
 </code></pre>
 
@@ -1086,13 +1086,13 @@
 
 </details>
 
-<a name="gateway_gateway_active_withdraw_cap"></a>
+
 
 ## Function `active_withdraw_cap`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_active_withdraw_cap">active_withdraw_cap</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>): <a href="../dependencies/sui/object.md#sui_object_ID">sui::object::ID</a>
+<pre><code><b>public</b> <b>fun</b> active_withdraw_cap(gateway: &gateway::gateway::Gateway): sui::object::ID
 </code></pre>
 
 
@@ -1101,8 +1101,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_active_withdraw_cap">active_withdraw_cap</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>): ID {
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_active_withdraw_cap">active_withdraw_cap</a>
+<pre><code><b>public</b> <b>fun</b> active_withdraw_cap(gateway: &Gateway): ID {
+    gateway.active_withdraw_cap
 }
 </code></pre>
 
@@ -1110,13 +1110,13 @@
 
 </details>
 
-<a name="gateway_gateway_active_whitelist_cap"></a>
+
 
 ## Function `active_whitelist_cap`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_active_whitelist_cap">active_whitelist_cap</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>): <a href="../dependencies/sui/object.md#sui_object_ID">sui::object::ID</a>
+<pre><code><b>public</b> <b>fun</b> active_whitelist_cap(gateway: &gateway::gateway::Gateway): sui::object::ID
 </code></pre>
 
 
@@ -1125,8 +1125,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_active_whitelist_cap">active_whitelist_cap</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>): ID {
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.<a href="../gateway/gateway.md#gateway_gateway_active_whitelist_cap">active_whitelist_cap</a>
+<pre><code><b>public</b> <b>fun</b> active_whitelist_cap(gateway: &Gateway): ID {
+    gateway.active_whitelist_cap
 }
 </code></pre>
 
@@ -1134,13 +1134,13 @@
 
 </details>
 
-<a name="gateway_gateway_vault_balance"></a>
+
 
 ## Function `vault_balance`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_vault_balance">vault_balance</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>): u64
+<pre><code><b>public</b> <b>fun</b> vault_balance&lt;T&gt;(gateway: &gateway::gateway::Gateway): u64
 </code></pre>
 
 
@@ -1149,12 +1149,12 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_vault_balance">vault_balance</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>): u64 {
-    <b>if</b> (!<a href="../gateway/gateway.md#gateway_gateway_is_whitelisted">is_whitelisted</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>)) {
+<pre><code><b>public</b> <b>fun</b> vault_balance&lt;T&gt;(gateway: &Gateway): u64 {
+    <b>if</b> (!is_whitelisted&lt;T&gt;(gateway)) {
         <b>return</b> 0
     };
-    <b>let</b> <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a> = <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;T&gt;();
-    <b>let</b> vault = bag::borrow&lt;String, <a href="../gateway/gateway.md#gateway_gateway_Vault">Vault</a>&lt;T&gt;&gt;(&<a href="../gateway/gateway.md#gateway_gateway">gateway</a>.vaults, <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>);
+    <b>let</b> coin_name = coin_name&lt;T&gt;();
+    <b>let</b> vault = bag::borrow&lt;String, Vault&lt;T&gt;&gt;(&gateway.vaults, coin_name);
     balance::value(&vault.balance)
 }
 </code></pre>
@@ -1163,13 +1163,13 @@
 
 </details>
 
-<a name="gateway_gateway_is_paused"></a>
+
 
 ## Function `is_paused`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_is_paused">is_paused</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>): bool
+<pre><code><b>public</b> <b>fun</b> is_paused(gateway: &gateway::gateway::Gateway): bool
 </code></pre>
 
 
@@ -1178,8 +1178,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_is_paused">is_paused</a>(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>): bool {
-    <a href="../gateway/gateway.md#gateway_gateway">gateway</a>.deposit_paused
+<pre><code><b>public</b> <b>fun</b> is_paused(gateway: &Gateway): bool {
+    gateway.deposit_paused
 }
 </code></pre>
 
@@ -1187,13 +1187,13 @@
 
 </details>
 
-<a name="gateway_gateway_is_whitelisted"></a>
+
 
 ## Function `is_whitelisted`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_is_whitelisted">is_whitelisted</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<a href="../gateway/gateway.md#gateway_gateway_Gateway">gateway::gateway::Gateway</a>): bool
+<pre><code><b>public</b> <b>fun</b> is_whitelisted&lt;T&gt;(gateway: &gateway::gateway::Gateway): bool
 </code></pre>
 
 
@@ -1202,12 +1202,12 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_is_whitelisted">is_whitelisted</a>&lt;T&gt;(<a href="../gateway/gateway.md#gateway_gateway">gateway</a>: &<a href="../gateway/gateway.md#gateway_gateway_Gateway">Gateway</a>): bool {
-    <b>let</b> vault_name = <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;T&gt;();
-    <b>if</b> (!bag::contains_with_type&lt;String, <a href="../gateway/gateway.md#gateway_gateway_Vault">Vault</a>&lt;T&gt;&gt;(&<a href="../gateway/gateway.md#gateway_gateway">gateway</a>.vaults, vault_name)) {
+<pre><code><b>public</b> <b>fun</b> is_whitelisted&lt;T&gt;(gateway: &Gateway): bool {
+    <b>let</b> vault_name = coin_name&lt;T&gt;();
+    <b>if</b> (!bag::contains_with_type&lt;String, Vault&lt;T&gt;&gt;(&gateway.vaults, vault_name)) {
         <b>return</b> <b>false</b>
     };
-    <b>let</b> vault = bag::borrow&lt;String, <a href="../gateway/gateway.md#gateway_gateway_Vault">Vault</a>&lt;T&gt;&gt;(&<a href="../gateway/gateway.md#gateway_gateway">gateway</a>.vaults, vault_name);
+    <b>let</b> vault = bag::borrow&lt;String, Vault&lt;T&gt;&gt;(&gateway.vaults, vault_name);
     vault.whitelisted
 }
 </code></pre>
@@ -1216,13 +1216,13 @@
 
 </details>
 
-<a name="gateway_gateway_coin_name"></a>
+
 
 ## Function `coin_name`
 
 
 
-<pre><code><b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;T&gt;(): <a href="../dependencies/std/ascii.md#std_ascii_String">std::ascii::String</a>
+<pre><code><b>fun</b> coin_name&lt;T&gt;(): std::ascii::String
 </code></pre>
 
 
@@ -1231,7 +1231,7 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="../gateway/gateway.md#gateway_gateway_coin_name">coin_name</a>&lt;T&gt;(): String {
+<pre><code><b>fun</b> coin_name&lt;T&gt;(): String {
     into_string(get&lt;T&gt;())
 }
 </code></pre>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0-set-on-publish",
   "description": "ZetaChain protocol contracts on Sui",
   "scripts": {
-    "docs": "scripts/docs.sh"
+    "docs": "sui move build --doc && scripts/docs.sh"
   },
   "files": [
     "gateway.json"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0-set-on-publish",
   "description": "ZetaChain protocol contracts on Sui",
   "scripts": {
-    "docs": "sui move build --doc && scripts/docs.sh"
+    "docs": "scripts/docs.sh"
   },
   "files": [
     "gateway.json"

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,6 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 sui move build --doc
 rm -rf docs
 mkdir -p docs
 rsync -a build/gateway/docs/gateway/ docs/
+
+find docs -name '*.md' -type f | while read -r file; do
+  sed -E -i.bak \
+    -e 's/<a name="[^"]*"><\/a>//g' \
+    -e 's/<a href="[^"]*"[^>]*>//g' \
+    -e 's/<\/a>//g' \
+    "$file"
+  rm -f "${file}.bak"
+done

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-sui move build --doc
 rm -rf docs
 mkdir -p docs
 rsync -a build/gateway/docs/gateway/ docs/

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -6,11 +6,18 @@ rm -rf docs
 mkdir -p docs
 rsync -a build/gateway/docs/gateway/ docs/
 
+if [[ "$(uname)" == "Darwin" ]]; then
+  # macOS (BSD sed)
+  sed_i() { sed -E -i '' "$@"; }
+else
+  # Linux (GNU sed)
+  sed_i() { sed -E -i "$@"; }
+fi
+
 find docs -name '*.md' -type f | while read -r file; do
-  sed -E -i.bak \
+  sed_i \
     -e 's/<a name="[^"]*"><\/a>//g' \
     -e 's/<a href="[^"]*"[^>]*>//g' \
     -e 's/<\/a>//g' \
     "$file"
-  rm -f "${file}.bak"
 done


### PR DESCRIPTION
Removed links to third-party and standard libs, because we're only showing protocol contract docs on the website and link to non-existing docs breaks the link checker: https://github.com/zeta-chain/docs/actions/runs/16568520438/job/46854391713

We can add the links back when docs website has better support for nested docs.