### PR TITLE
feat: add refund logic

### DIFF
--- a/contracts/gateway/sources/gateway.move
+++ b/contracts/gateway/sources/gateway.move
@@ -23,6 +23,9 @@ const EInactiveWithdrawCap: u64 = 5;
 const EInactiveWhitelistCap: u64 = 6;
 const EDepositPaused: u64 = 7;
 const EInvalidSenderAddress: u64 = 8;
+const EVaultNotFound: u64 = 9;
+const EZeroAmount: u64 = 10;
+const ESuiRefundNotAllowed: u64 = 11;
 
 const PayloadMaxLength: u64 = 1024;
 
@@ -106,6 +109,13 @@ public struct DonateEvent has copy, drop {
     coin_type: String,
     amount: u64,
     sender: address,
+}
+
+public struct RefundEvent has copy, drop {
+    coin_type: String,
+    amount: u64,
+    sender: address,
+    receiver: address,
 }
 
 // === Initialization ===
@@ -252,6 +262,25 @@ entry fun reset_nonce(gateway: &mut Gateway, nonce: u64, _cap: &AdminCap) {
     gateway.nonce = nonce;
 }
 
+// refund allows the admin to return tokens from custody to a Sui address during shutdown
+entry fun refund<T>(
+    gateway: &mut Gateway,
+    amount: u64,
+    receiver: address,
+    cap: &AdminCap,
+    ctx: &mut TxContext,
+) {
+    let coins = refund_impl<T>(gateway, amount, receiver, cap, ctx);
+    transfer::public_transfer(coins, receiver);
+
+    event::emit(RefundEvent {
+        coin_type: coin_name<T>(),
+        amount,
+        sender: tx_context::sender(ctx),
+        receiver,
+    });
+}
+
 // === Deposit Functions ===
 
 // deposit allows the user to deposit tokens into the gateway
@@ -365,6 +394,24 @@ public fun withdraw_impl<T>(
     let coins_gas_budget = coin::take(&mut sui_vault.balance, gas_budget, ctx);
 
     (coins_out, coins_gas_budget)
+}
+
+public fun refund_impl<T>(
+    gateway: &mut Gateway,
+    amount: u64,
+    receiver: address,
+    _cap: &AdminCap,
+    ctx: &mut TxContext,
+): Coin<T> {
+    assert!(receiver != @0x0, EInvalidReceiverAddress);
+    assert!(amount > 0, EZeroAmount);
+    assert!(coin_name<T>() != coin_name<SUI>(), ESuiRefundNotAllowed);
+
+    let coin_name = coin_name<T>();
+    assert!(bag::contains_with_type<String, Vault<T>>(&gateway.vaults, coin_name), EVaultNotFound);
+
+    let vault = bag::borrow_mut<String, Vault<T>>(&mut gateway.vaults, coin_name);
+    coin::take(&mut vault.balance, amount, ctx)
 }
 
 // === Admin Functions ===

--- a/contracts/gateway/tests/gateway_tests.move
+++ b/contracts/gateway/tests/gateway_tests.move
@@ -41,6 +41,10 @@ use gateway::gateway::{
     EInvalidSenderAddress,
     set_message_context,
     reset_message_context,
+    refund,
+    EVaultNotFound,
+    EZeroAmount,
+    ESuiRefundNotAllowed,
 };
 use sui::coin::{Self, Coin};
 
@@ -1063,6 +1067,238 @@ fun test_custom_coin() {
         ts::return_shared(gateway);
         transfer::public_transfer(coins, @0xA);
         transfer::public_transfer(coins_gas, @0xA);
+    };
+    ts::end(scenario);
+}
+
+#[test_only]
+const RefundAmount: u64 = 13;
+
+#[test_only]
+const RefundReceiver: address = @0xC;
+
+#[test]
+fun test_refund() {
+    let mut scenario = ts::begin(@0xA);
+    setup(&mut scenario);
+
+    ts::next_tx(&mut scenario, @0xA);
+    {
+        init_fake_usdc(scenario.ctx());
+    };
+
+    ts::next_tx(&mut scenario, @0xA);
+    {
+        let mut gateway = scenario.take_shared<Gateway>();
+        let whitelist_cap = ts::take_from_address<WhitelistCap>(&scenario, @0xA);
+        whitelist_impl<FAKE_USDC>(&mut gateway, &whitelist_cap);
+
+        let coin = coin::mint_for_testing<FAKE_USDC>(AmountTest, scenario.ctx());
+        let eth_addr = ValidEthAddr.to_string().to_ascii();
+        deposit(&mut gateway, coin, eth_addr, scenario.ctx());
+        assert!(vault_balance<FAKE_USDC>(&gateway) == AmountTest);
+
+        ts::return_to_address(@0xA, whitelist_cap);
+        ts::return_shared(gateway);
+    };
+
+    ts::next_tx(&mut scenario, @0xA);
+    {
+        let mut gateway = scenario.take_shared<Gateway>();
+        let admin_cap = ts::take_from_address<AdminCap>(&scenario, @0xA);
+        let nonce_before = gateway.nonce();
+
+        refund<FAKE_USDC>(
+            &mut gateway,
+            RefundAmount,
+            RefundReceiver,
+            &admin_cap,
+            scenario.ctx(),
+        );
+
+        assert!(vault_balance<FAKE_USDC>(&gateway) == AmountTest - RefundAmount);
+        assert!(gateway.nonce() == nonce_before);
+
+        ts::return_to_address(@0xA, admin_cap);
+        ts::return_shared(gateway);
+    };
+
+    ts::next_tx(&mut scenario, RefundReceiver);
+    {
+        let coin = ts::take_from_address<Coin<FAKE_USDC>>(&scenario, RefundReceiver);
+        assert!(coin::value(&coin) == RefundAmount);
+        ts::return_to_address(RefundReceiver, coin);
+    };
+
+    ts::end(scenario);
+}
+
+#[test]
+fun test_refund_unwhitelisted() {
+    let mut scenario = ts::begin(@0xA);
+    setup(&mut scenario);
+
+    ts::next_tx(&mut scenario, @0xA);
+    {
+        init_fake_usdc(scenario.ctx());
+    };
+
+    ts::next_tx(&mut scenario, @0xA);
+    {
+        let mut gateway = scenario.take_shared<Gateway>();
+        let whitelist_cap = ts::take_from_address<WhitelistCap>(&scenario, @0xA);
+        let admin_cap = ts::take_from_address<AdminCap>(&scenario, @0xA);
+
+        whitelist_impl<FAKE_USDC>(&mut gateway, &whitelist_cap);
+
+        let coin = coin::mint_for_testing<FAKE_USDC>(AmountTest, scenario.ctx());
+        let eth_addr = ValidEthAddr.to_string().to_ascii();
+        deposit(&mut gateway, coin, eth_addr, scenario.ctx());
+
+        unwhitelist_impl<FAKE_USDC>(&mut gateway, &admin_cap);
+        assert!(!is_whitelisted<FAKE_USDC>(&gateway));
+
+        refund<FAKE_USDC>(
+            &mut gateway,
+            RefundAmount,
+            RefundReceiver,
+            &admin_cap,
+            scenario.ctx(),
+        );
+
+        ts::return_to_address(@0xA, whitelist_cap);
+        ts::return_to_address(@0xA, admin_cap);
+        ts::return_shared(gateway);
+    };
+
+    ts::next_tx(&mut scenario, RefundReceiver);
+    {
+        let coin = ts::take_from_address<Coin<FAKE_USDC>>(&scenario, RefundReceiver);
+        assert!(coin::value(&coin) == RefundAmount);
+        ts::return_to_address(RefundReceiver, coin);
+    };
+
+    ts::end(scenario);
+}
+
+#[test, expected_failure(abort_code = ESuiRefundNotAllowed)]
+fun test_refund_sui_not_allowed() {
+    let mut scenario = ts::begin(@0xA);
+    setup(&mut scenario);
+
+    ts::next_tx(&mut scenario, @0xA);
+    {
+        let mut gateway = scenario.take_shared<Gateway>();
+        let admin_cap = ts::take_from_address<AdminCap>(&scenario, @0xA);
+
+        refund<SUI>(
+            &mut gateway,
+            RefundAmount,
+            RefundReceiver,
+            &admin_cap,
+            scenario.ctx(),
+        );
+
+        ts::return_to_address(@0xA, admin_cap);
+        ts::return_shared(gateway);
+    };
+    ts::end(scenario);
+}
+
+#[test, expected_failure(abort_code = EInvalidReceiverAddress)]
+fun test_refund_zero_receiver() {
+    let mut scenario = ts::begin(@0xA);
+    setup(&mut scenario);
+
+    ts::next_tx(&mut scenario, @0xA);
+    {
+        init_fake_usdc(scenario.ctx());
+    };
+
+    ts::next_tx(&mut scenario, @0xA);
+    {
+        let mut gateway = scenario.take_shared<Gateway>();
+        let whitelist_cap = ts::take_from_address<WhitelistCap>(&scenario, @0xA);
+        let admin_cap = ts::take_from_address<AdminCap>(&scenario, @0xA);
+
+        whitelist_impl<FAKE_USDC>(&mut gateway, &whitelist_cap);
+
+        let coin = coin::mint_for_testing<FAKE_USDC>(AmountTest, scenario.ctx());
+        let eth_addr = ValidEthAddr.to_string().to_ascii();
+        deposit(&mut gateway, coin, eth_addr, scenario.ctx());
+
+        refund<FAKE_USDC>(
+            &mut gateway,
+            RefundAmount,
+            @0x0,
+            &admin_cap,
+            scenario.ctx(),
+        );
+
+        ts::return_to_address(@0xA, whitelist_cap);
+        ts::return_to_address(@0xA, admin_cap);
+        ts::return_shared(gateway);
+    };
+    ts::end(scenario);
+}
+
+#[test, expected_failure(abort_code = EZeroAmount)]
+fun test_refund_zero_amount() {
+    let mut scenario = ts::begin(@0xA);
+    setup(&mut scenario);
+
+    ts::next_tx(&mut scenario, @0xA);
+    {
+        init_fake_usdc(scenario.ctx());
+    };
+
+    ts::next_tx(&mut scenario, @0xA);
+    {
+        let mut gateway = scenario.take_shared<Gateway>();
+        let whitelist_cap = ts::take_from_address<WhitelistCap>(&scenario, @0xA);
+        let admin_cap = ts::take_from_address<AdminCap>(&scenario, @0xA);
+
+        whitelist_impl<FAKE_USDC>(&mut gateway, &whitelist_cap);
+
+        let coin = coin::mint_for_testing<FAKE_USDC>(AmountTest, scenario.ctx());
+        let eth_addr = ValidEthAddr.to_string().to_ascii();
+        deposit(&mut gateway, coin, eth_addr, scenario.ctx());
+
+        refund<FAKE_USDC>(
+            &mut gateway,
+            0,
+            RefundReceiver,
+            &admin_cap,
+            scenario.ctx(),
+        );
+
+        ts::return_to_address(@0xA, whitelist_cap);
+        ts::return_to_address(@0xA, admin_cap);
+        ts::return_shared(gateway);
+    };
+    ts::end(scenario);
+}
+
+#[test, expected_failure(abort_code = EVaultNotFound)]
+fun test_refund_vault_not_found() {
+    let mut scenario = ts::begin(@0xA);
+    setup(&mut scenario);
+
+    ts::next_tx(&mut scenario, @0xA);
+    {
+        let mut gateway = scenario.take_shared<Gateway>();
+        let admin_cap = ts::take_from_address<AdminCap>(&scenario, @0xA);
+
+        refund<FAKE_USDC>(
+            &mut gateway,
+            RefundAmount,
+            RefundReceiver,
+            &admin_cap,
+            scenario.ctx(),
+        );
+
+        ts::return_to_address(@0xA, admin_cap);
+        ts::return_shared(gateway);
     };
     ts::end(scenario);
 }


### PR DESCRIPTION
Closing: https://github.com/zeta-chain/protocol-contracts-sui/issues/73

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves custodied funds out of the gateway via a new AdminCap-gated path; mitigated by SUI blocking and tests, but still custody-critical at shutdown.
> 
> **Overview**
> Adds an **admin-only refund path** so custody in gateway vaults can be sent back to a Sui address during shutdown, without going through the TSS **withdraw** flow (no `WithdrawCap`, no nonce bump).
> 
> `refund` / `refund_impl` take coins from an existing vault by type, require `AdminCap`, and enforce non-zero receiver and amount, vault existence (`EVaultNotFound`), and **no SUI refunds** (`ESuiRefundNotAllowed`) so the gas reserve vault stays protected. Refunds are **not** gated on whitelist status (covered by tests). Each successful refund emits `RefundEvent` and transfers coins to the receiver.
> 
> New abort codes and a broad test suite cover happy path, unwhitelisted vaults, SUI blocked, zero receiver/amount, and missing vault.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3cc464fc3801df13d3b4be5c19d1b456b7d8b62. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->