### PR TITLE
feat: enable native token refund

### DIFF
--- a/contracts/gateway/sources/gateway.move
+++ b/contracts/gateway/sources/gateway.move
@@ -25,7 +25,6 @@ const EDepositPaused: u64 = 7;
 const EInvalidSenderAddress: u64 = 8;
 const EVaultNotFound: u64 = 9;
 const EZeroAmount: u64 = 10;
-const ESuiRefundNotAllowed: u64 = 11;
 
 const PayloadMaxLength: u64 = 1024;
 
@@ -405,7 +404,6 @@ public fun refund_impl<T>(
 ): Coin<T> {
     assert!(receiver != @0x0, EInvalidReceiverAddress);
     assert!(amount > 0, EZeroAmount);
-    assert!(coin_name<T>() != coin_name<SUI>(), ESuiRefundNotAllowed);
 
     let coin_name = coin_name<T>();
     assert!(bag::contains_with_type<String, Vault<T>>(&gateway.vaults, coin_name), EVaultNotFound);

--- a/contracts/gateway/tests/gateway_tests.move
+++ b/contracts/gateway/tests/gateway_tests.move
@@ -44,7 +44,6 @@ use gateway::gateway::{
     refund,
     EVaultNotFound,
     EZeroAmount,
-    ESuiRefundNotAllowed,
 };
 use sui::coin::{Self, Coin};
 
@@ -1181,8 +1180,8 @@ fun test_refund_unwhitelisted() {
     ts::end(scenario);
 }
 
-#[test, expected_failure(abort_code = ESuiRefundNotAllowed)]
-fun test_refund_sui_not_allowed() {
+#[test]
+fun test_refund_sui() {
     let mut scenario = ts::begin(@0xA);
     setup(&mut scenario);
 
@@ -1190,6 +1189,7 @@ fun test_refund_sui_not_allowed() {
     {
         let mut gateway = scenario.take_shared<Gateway>();
         let admin_cap = ts::take_from_address<AdminCap>(&scenario, @0xA);
+        let nonce_before = gateway.nonce();
 
         refund<SUI>(
             &mut gateway,
@@ -1199,9 +1199,20 @@ fun test_refund_sui_not_allowed() {
             scenario.ctx(),
         );
 
+        assert!(vault_balance<SUI>(&gateway) == AmountTest - RefundAmount);
+        assert!(gateway.nonce() == nonce_before);
+
         ts::return_to_address(@0xA, admin_cap);
         ts::return_shared(gateway);
     };
+
+    ts::next_tx(&mut scenario, RefundReceiver);
+    {
+        let coin = ts::take_from_address<Coin<SUI>>(&scenario, RefundReceiver);
+        assert!(coin::value(&coin) == RefundAmount);
+        ts::return_to_address(RefundReceiver, coin);
+    };
+
     ts::end(scenario);
 }
 


### PR DESCRIPTION
Remove checkers for the native token refund.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Admin `refund` can now move SUI out of the gateway vault (previously forbidden), which affects custody during shutdown but still requires `AdminCap` and existing refund validations.
> 
> **Overview**
> **Enables admin `refund` for native SUI** by removing the guard that rejected `refund_impl` when `T` was `SUI`.
> 
> The `ESuiRefundNotAllowed` error and its assert in `refund_impl` are deleted; other refund checks (non-zero receiver, positive amount, vault exists) are unchanged. Tests now expect a successful SUI refund—vault balance decreases, withdrawal **nonce** stays the same, and the receiver gets the coin—instead of an abort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3416eed57c67e999b0a83d36467b89544c4d2246. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->